### PR TITLE
fixed: avatarの画像サイズが1:1でない場合にアスペクト比が崩れてしまうのを修正

### DIFF
--- a/src/styles/components/_ScrollableMembers.scss
+++ b/src/styles/components/_ScrollableMembers.scss
@@ -38,6 +38,7 @@
 .scrollable-member__img {
   border-radius: 18px;
   margin: 0 auto;
+  object-fit: cover;
 }
 
 .scrollable-member__name {


### PR DESCRIPTION
お手すきで大丈夫です 🙏 

|before|after|
--- | ---
|<img width="364" alt="スクリーンショット 2022-03-11 12 07 59" src="https://user-images.githubusercontent.com/44659317/157794758-ce4e9db5-af34-46d4-8254-308b11d68a24.png">|<img width="360" alt="スクリーンショット 2022-03-11 12 08 05" src="https://user-images.githubusercontent.com/44659317/157794778-1005a63f-be1b-497e-8f11-ca6124a69220.png">|

現状正常に表示されているAvatarにも影響はないと思います