### PR TITLE
RSS フィード内の URL が localhost になってしまっているのを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "run-s build:posts build:feed build:next",
     "build:posts": "ts-node --project tsconfig.builder.json ./src/builder/posts.ts",
-    "build:feed": "ts-node --project tsconfig.builder.json ./src/builder/feed.ts",
+    "build:feed": "NODE_ENV=production ts-node --project tsconfig.builder.json ./src/builder/feed.ts",
     "build:next": "next build",
     "start": "next start",
     "export": "next export",


### PR DESCRIPTION
## 事象

https://blog.3-shake.com/feed.xml
RSS フィード内の link の URL が localhost になってしまっていました。

## やったこと

`build:feed` 実行時に `NODE_ENV=production` を設定するようにしました。
これにより `site.config.ts` の `siteRoot` が `https://blog.3-shake.com/` になり、 RSS フィードにもそれが含まれるようになります。