### PR TITLE
メンバーリストのスタイルを修正

### DIFF
--- a/src/styles/components/_ScrollableMembers.scss
+++ b/src/styles/components/_ScrollableMembers.scss
@@ -24,10 +24,12 @@
   flex-shrink: 0;
   width: 90px;
   margin-right: 23px;
-  margin-left: -5px;
   text-align: center;
   line-height: 1.5;
   scroll-snap-align: center;
+  &:not(:first-child) {
+    margin-left: -5px;
+  }
 }
 .scrollable-member__image,
 .scrollable-member__img,


### PR DESCRIPTION
## やったこと

メンバーリストの先頭のアイテムに `margin-left: -5px` があたって名前がはみ出ていました。
なので、先頭のアイテムには当該スタイルが適用されないようにしました。