### PR TITLE
siteRoot の末尾のスラッシュを削除

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -6,7 +6,7 @@ export const config = {
   },
   siteRoot:
     process.env.NODE_ENV === "production"
-      ? "https://blog.3-shake.com/"
+      ? "https://blog.3-shake.com"
       : "http://localhost:3000",
   headerLinks: [
     {


### PR DESCRIPTION
## やったこと

PageSEO によって設定される meta タグの URL とかが↓のようにスラッシュが二重になってしまっていました。

```html
<meta property="og:image" content="https://blog.3-shake.com//og.png" />
```

なので siteRoot の URL の末尾のスラッシュを削除しました。