### PR TITLE
stylesheet の link を _document.tsx に移動

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,10 +15,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           type="image/png"
           href={`${config.siteRoot}/logo.png`}
         />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;700&family=Roboto:wght@300;400;500;700&display=swap"
-          rel="stylesheet"
-        />
       </Head>
       <SiteHeader />
       <Component {...pageProps} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,18 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="ja">
+      <Head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;700&family=Roboto:wght@300;400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
「stylesheet の link を `next/head` を使って追加しないでね」っていうエラーが出ていたので、メッセージに従って Document を使用するように修正しました。

```
Do not add stylesheets using next/head (see <link rel="stylesheet"> tag with href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;700&family=Roboto:wght@300;400;500;700&display=swap"). Use Document instead.
See more info here: https://nextjs.org/docs/messages/no-stylesheets-in-head-component
```

参考:

- https://nextjs.org/docs/messages/no-stylesheets-in-head-component