### PR TITLE
fix: next exportが使えなくなったためコマンドとGitHub Actionのコマンドの修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,16 @@ jobs:
           node-version-file: package.json
           cache: yarn
 
-      - run: yarn
+      - name: Enable Corepack
+        run: corepack enable
 
-      - run: yarn build
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build application
+        run: yarn build
         # env:
         #   URL_PREFIX: team-blog-hub
-
-      - run: yarn export
 
       - name: Copy CNAME
         run: cp CNAME out/CNAME

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,12 @@
+export default {
+  output: 'export',
+ 
+  // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
+  // trailingSlash: true,
+ 
+  // Optional: Prevent automatic `/me` -> `/me/`, instead preserve `href`
+  // skipTrailingSlashRedirect: true,
+ 
+  // Optional: Change the output directory `out` -> `dist`
+  // distDir: 'dist',
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build:feed": "NODE_ENV=production ts-node --project tsconfig.builder.json ./src/builder/feed.ts",
     "build:next": "next build",
     "start": "next start",
-    "export": "next export",
     "typecheck": "tsc --noEmit",
     "format:fix": "prettier --write ."
   },


### PR DESCRIPTION
## やったこと
- #128 の対応により、Next.jsのコマンドも変更する必要があったため対応
  - https://github.com/3-shake/3-shake-engineers-blogs/actions/runs/16741941207/job/47391958189
    - https://nextjs.org/docs/app/guides/static-exports

## テスト
- ローカル環境での画面表示 -> OK
- ローカル環境でのbuild -> OK