### PR TITLE
refactor: update node 18 -> 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "scripts": {
     "dev": "next dev",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/node": "^18.14.2",
+    "@types/node": "22.10.2",
     "@types/react": "18.2.0",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
@@ -42,7 +42,7 @@
     "typescript": "^4.9.5"
   },
   "volta": {
-    "node": "18.20.8",
+    "node": "22.18.0",
     "yarn": "4.9.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "3-shake-engineers-blogs@workspace:."
   dependencies:
     "@types/fs-extra": "npm:11.0.4"
-    "@types/node": "npm:^18.14.2"
+    "@types/node": "npm:22.10.2"
     "@types/react": "npm:18.2.0"
     "@types/react-dom": "npm:^18.0.11"
     "@typescript-eslint/eslint-plugin": "npm:^4.4.1"
@@ -626,10 +626,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^18.14.2":
+"@types/node@npm:*":
   version: 18.14.2
   resolution: "@types/node@npm:18.14.2"
   checksum: 10c0/996387e0004198cb25bd442b913744e302ef99975ef783c44fc1531e97f1d06ef9a09748bc562988005455f9500e14e60cc6fb0689d32b023a116394512ae175
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:22.10.2":
+  version: 22.10.2
+  resolution: "@types/node@npm:22.10.2"
+  dependencies:
+    undici-types: "npm:~6.20.0"
+  checksum: 10c0/2c7b71a040f1ef5320938eca8ebc946e6905caa9bbf3d5665d9b3774a8d15ea9fab1582b849a6d28c7fc80756a62c5666bc66b69f42f4d5dafd1ccb193cdb4ac
   languageName: node
   linkType: hard
 
@@ -4118,6 +4127,13 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     which-boxed-primitive: "npm:^1.1.1"
   checksum: 10c0/7dbd35ab02b0e05fe07136c72cb9355091242455473ec15057c11430129bab38b7b3624019b8778d02a881c13de44d63cd02d122ee782fb519e1de7775b5b982
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.20.0":
+  version: 6.20.0
+  resolution: "undici-types@npm:6.20.0"
+  checksum: 10c0/68e659a98898d6a836a9a59e6adf14a5d799707f5ea629433e025ac90d239f75e408e2e5ff086afc3cace26f8b26ee52155293564593fbb4a2f666af57fc59bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## やったこと
#121 関連の対応です。
- nodeを`18.20.8` -> `22.18.0`に更新
  - 18系はLTSが既に切れているため
- @types/nodeを`^18.14.2` -> `22.10.2`に更新

## テスト
- ローカル環境での画面表示 -> OK
- ローカル環境でのbuild -> OK