### PR TITLE
chore: fixed version to npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react-hooks": "^4.1.2",
     "feed": "^4.2.2",
     "fs-extra": "11.3.0",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all": "4.1.5",
     "prettier": "^2.1.2",
     "rss-parser": "3.13.0",
     "sass": "1.89.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
     feed: "npm:^4.2.2"
     fs-extra: "npm:11.3.0"
     next: "npm:15.4.3"
-    npm-run-all: "npm:^4.1.5"
+    npm-run-all: "npm:4.1.5"
     prettier: "npm:^2.1.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -2875,7 +2875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-all@npm:^4.1.5":
+"npm-run-all@npm:4.1.5":
   version: 4.1.5
   resolution: "npm-run-all@npm:4.1.5"
   dependencies:


### PR DESCRIPTION
## やったこと
#121 関連の対応です。
- npm-run-allを`^4.1.5` -> `4.1.5`(固定)に更新

## テスト
- ローカル環境での画面表示 -> OK
- ローカル環境でのbuild -> OK