### PR TITLE
fix(ci): ビルド信頼性の向上とワークフロー強化

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,17 @@ on:
     - cron: "30 11 * * *" # 8:30 PM JST every day
   workflow_dispatch:
 
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -29,10 +37,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('next.config.js', 'tsconfig.json') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
-            ${{ runner.os }}-nextjs-
+
+      - name: Type check
+        run: yarn typecheck
 
       - name: Build application
         run: yarn build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,13 @@ name: Build Next.js app
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -24,10 +28,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('next.config.js', 'tsconfig.json') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
-            ${{ runner.os }}-nextjs-
 
       - name: Type check
         run: yarn typecheck

--- a/members.ts
+++ b/members.ts
@@ -681,7 +681,7 @@ export const members: Member[] = [
     bio: "Engineer",
     avatarSrc: "/avatars/riiim.png",
     sources: [
-      "http://rowicy.com/RiiiM/rss.xml",
+      "https://rowicy.com/RiiiM/rss.xml",
     ],
     includeUrlRegex: "",
     twitterUsername: "riiimparm",

--- a/src/builder/posts.ts
+++ b/src/builder/posts.ts
@@ -53,7 +53,7 @@ async function fetchFeedItems(url: string): Promise<FeedItem[]> {
           link,
           contentSnippet: contentSnippet?.replace(/\n|\u2028/g, ""),
           isoDate,
-          dateMiliSeconds: isoDate ? new Date(isoDate).getTime() : 0,
+          dateMiliSeconds: isoDate ? (new Date(isoDate).getTime() || 0) : 0,
         };
         return item;
       })
@@ -92,29 +92,41 @@ async function getMemberFeedItems(member: Member): Promise<PostItem[]> {
   }));
 
   if (includeUrlRegex) {
-    const regex = new RegExp(includeUrlRegex);
-    postItems = postItems.filter((item) => {
-      const matches = item.link.match(regex);
-      if (!matches) {
-        console.debug(
-          `Filtered out item not matching includeUrlRegex: ${item.link}`,
-        );
-      }
-      return matches;
-    });
+    try {
+      const regex = new RegExp(includeUrlRegex);
+      postItems = postItems.filter((item) => {
+        const matches = item.link.match(regex);
+        if (!matches) {
+          console.debug(
+            `Filtered out item not matching includeUrlRegex: ${item.link}`,
+          );
+        }
+        return matches;
+      });
+    } catch (error) {
+      console.error(
+        `Invalid includeUrlRegex "${includeUrlRegex}" for ${name}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
   }
 
   if (excludeUrlRegex) {
-    const regex = new RegExp(excludeUrlRegex);
-    postItems = postItems.filter((item) => {
-      const matches = item.link.match(regex);
-      if (matches) {
-        console.debug(
-          `Filtered out item matching excludeUrlRegex: ${item.link}`,
-        );
-      }
-      return !matches;
-    });
+    try {
+      const regex = new RegExp(excludeUrlRegex);
+      postItems = postItems.filter((item) => {
+        const matches = item.link.match(regex);
+        if (matches) {
+          console.debug(
+            `Filtered out item matching excludeUrlRegex: ${item.link}`,
+          );
+        }
+        return !matches;
+      });
+    } catch (error) {
+      console.error(
+        `Invalid excludeUrlRegex "${excludeUrlRegex}" for ${name}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
   }
 
   return postItems;


### PR DESCRIPTION
## Summary
- ジョブに `timeout-minutes` を追加（deploy: 20分, PR build: 15分）でハング時のランナー消費を防止
- deploy ワークフローに `concurrency` グループを追加し、同時デプロイの競合を防止
- 両ワークフローに明示的な `permissions` を追加（最小権限の原則）
- deploy ワークフローに `typecheck` ステップを追加（PR では実行済みだがデプロイでは未実行だった）
- Next.js キャッシュキーを `yarn.lock` + 設定ファイルのみに簡素化（全 TS ファイルハッシュによるキャッシュ無効化を防止）
- `includeUrlRegex` / `excludeUrlRegex` の RegExp 構築に try-catch を追加（不正な正規表現によるビルドクラッシュを防止）
- `isoDate` が不正な場合の NaN ハンドリングを修正（ソート順の崩壊を防止）
- `riiim` メンバーのフィード URL を HTTP から HTTPS に修正

## Test plan
- [ ] CI の Build Next.js app が正常に完了すること
- [ ] deploy ワークフローに timeout-minutes, concurrency, permissions, typecheck が含まれること
- [ ] pr.yml に timeout-minutes, permissions が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)