### PR TITLE
perf: Google FontsをNext.js組み込みフォント(next/font/google)に移行

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,29 @@
 import { AppProps } from "next/app";
 import Head from "next/head";
+import { Roboto, Open_Sans } from "next/font/google";
 import { config } from "@site.config";
 import { SiteHeader } from "@src/components/SiteHeader";
 import { SiteFooter } from "@src/components/SiteFooter";
 
 import "@src/styles/globals.scss";
 
+const roboto = Roboto({
+  weight: ["300", "400", "500", "700"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-roboto",
+});
+
+const openSans = Open_Sans({
+  weight: ["400", "500", "700"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-open-sans",
+});
+
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <div className={`${roboto.variable} ${openSans.variable} app-wrapper`}>
       <Head>
         <link
           rel="icon shortcut"
@@ -19,6 +34,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <SiteHeader />
       <Component {...pageProps} />
       <SiteFooter />
-    </>
+    </div>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,12 +3,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="ja">
-      <Head>
-        <link
-          href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;700&family=Roboto:wght@300;400;500;700&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -22,7 +22,10 @@ body {
   background: var(--color-base-background);
   word-break: break-word;
   word-wrap: break-word;
-  font-family: "Roboto", "Open Sans", sans-serif;
+}
+
+.app-wrapper {
+  font-family: var(--font-roboto), var(--font-open-sans), sans-serif;
 }
 
 img {


### PR DESCRIPTION
<!-- publicリポジトリのため記載する情報に気をつけてください -->
## やったこと
close #288 

### 背景
<!-- このPRでやったことを簡潔に書いてください。 -->
Google Fontsを `<link rel="stylesheet">` で読み込む方式はレンダリングをブロックし、
LCP（Largest Contentful Paint）スコアに悪影響を与える。
`next/font/google` を使うことで外部リクエストが不要になり、
フォントがビルド時にself-hostされるためレンダリングブロッキングが解消される。

- `_document.tsx` からレンダリングブロッキングなGoogle Fontsの `<link rel="stylesheet">` を削除
- `next/font/google` を使い、Roboto・Open Sansをビルド時にself-hostするよう移行
- CSS変数（`--font-roboto`, `--font-open-sans`）経由でフォントを適用し、`_base.scss` を更新

## テスト
<!-- テストした方法、テストした内容について書いてください。ない場合はskip -->

## 動作確認
<!-- SSなど。UIや既存に跳ねる場合の対応は記述や添付等してください -->
表示崩れ等、特になし

## その他
<!-- 
その他自由記述です。
ドキュメントなどに記載すべきことは記載し、そのリンクを貼ってください。
-->
