### PR TITLE
fix: 低速回線でメンバー画像がずれるバグを修正

### DIFF
--- a/src/components/ScrollableMembers.tsx
+++ b/src/components/ScrollableMembers.tsx
@@ -14,9 +14,9 @@ export const ScrollableMembers: React.FC = () => {
 
   return (
     <div className="scrollable-members">
-      {shuffledMembers.map((member, i) => (
+      {shuffledMembers.map((member) => (
         <Link
-          key={`scrollable-member-${i}`}
+          key={member.id}
           href={getMemberPath(member.id)}
           className="scrollable-member__link"
         >


### PR DESCRIPTION
## Summary

- `ScrollableMembers` でシャッフル後に別メンバーの画像が表示されるバグを修正

**原因**: `key={`scrollable-member-${i}`}` のインデックスベースのキーにより、`useEffect` でのシャッフル時に React が DOM ノードを移動せず `<img src>` を書き換えていた。低速回線では旧画像がロード完了まで表示され続けるため、メンバー名と画像がずれる状態が発生。

**修正**: `key={member.id}` に変更し、React がシャッフル後も各メンバーの DOM ノードを正しい位置に移動するようにした。これにより不要な画像の再ロードが発生しなくなる。

## Test plan

- [ ] メンバー一覧ページを開き、スクロールできるメンバーリストで各メンバーの名前と画像が一致していることを確認
- [ ] ブラウザの DevTools でネットワーク速度を「Slow 3G」に設定し、同じ画像が複数表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)