### PR TITLE
fix: npm-run-all2 を minimumReleaseAgeExclude に追加して Renovate の lockfile 更新失敗を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 trustPolicy: no-downgrade
 minimumReleaseAge: "3 days"
+minimumReleaseAgeExclude:
+  - npm-run-all2
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加し、`npm-run-all2` を対象外に設定
- Renovate が `pnpm-lock.yaml` を再生成する際に `ERR_PNPM_NO_MATURE_MATCHING_VERSION` エラーが発生していた問題を修正

## 背景

Renovate が各 PR（next, eslint, fs-extra など）のブランチで `pnpm install` を実行すると、pnpm が `npm-run-all2@8.0.4` に対して `minimumReleaseAge` 制約チェックを行い失敗していた。

`npm-run-all2@8.0.4` は公開から 350 日以上経過しているが、Renovate のホスト環境にあるグローバルな pnpm 設定がプロジェクトの `"3 days"` 設定より厳しい値で上書きしている可能性がある。`minimumReleaseAgeExclude` に追加することで、このパッケージのみチェックをスキップさせる。

## Test plan

- [ ] このPRを `main` にマージ後、Renovate の既存 PR（#319, #320, #322）で「rebase!」トリガーまたはチェックボックスをクリックしてリトライし、`pnpm-lock.yaml` が正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)