### PR TITLE
fix: minimumReleaseAge を pnpm-workspace.yaml から .npmrc に移動

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-prefix=
 strict-peer-dependencies=true
+minimumReleaseAge=4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 trustPolicy: no-downgrade
-minimumReleaseAge: "3 days"
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` の `minimumReleaseAge: "3 days"`（文字列形式）が正しく解釈されず、601 日前・993 日前など明らかに古いパッケージでもインストールが失敗するバグがあった
- `.npmrc` の分単位数値形式（`minimumReleaseAge=4320` = 3日）に変更することで正常動作を確認
- `renovate.json5` はすでに `minimumReleaseAge: "5 days"` が設定されており、Renovate PR 作成時には必ず 2 日以上のバッファが確保される

## Test plan

- [ ] `pnpm install` が古いパッケージ（`@eslint/js@8.57.1` 等）で失敗しないことを確認
- [ ] 各 Renovate ブランチ（#319, #320）の CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)