### PR TITLE
fix: semver@6.3.1 を trustPolicyExclude に追加して Renovate の lockfile 更新失敗を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: "2024-01-01"
+trustPolicyExclude:
+  - semver@6.3.1
 
 allowBuilds:
   '@parcel/watcher': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: "2024-01-01"
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` に `trustPolicyExclude: [semver@6.3.1]` を追加
- Renovate が `pnpm-lock.yaml` を再生成する際に `ERR_PNPM_TRUST_DOWNGRADE` エラーが発生していた問題を修正

## 背景

`trustPolicy: no-downgrade` により、`eslint-plugin-react@7.37.5` の依存パッケージ `semver@6.3.1` がブロックされていた。`semver@6.3.1` は provenance attestation なしで公開されているが、それより前に attestation ありのバージョンが存在するため「信頼の降格」と判定される。

## Test plan

- [ ] このPRを `main` にマージ後、Renovate PR（#327, #328, #329）でリトライし、`pnpm-lock.yaml` が正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)