### PR TITLE
fix: trustPolicyIgnoreAfter で Renovate の lockfile 更新失敗を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 trustPolicy: no-downgrade
-trustPolicyExclude:
-  - semver@6.3.1
+trustPolicyIgnoreAfter: "2025-01-01"
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary

- `trustPolicyExclude` を廃止し `trustPolicyIgnoreAfter: "2025-01-01"` に変更
- 2025年より前に公開されたパッケージを trust チェック対象外にすることで、provenance attestation 導入前後の移行期パッケージによる誤検知を一括解消

## 背景

`trustPolicy: no-downgrade` により Renovate が `pnpm-lock.yaml` を再生成できない状態が続いていた。パッケージ単位の `trustPolicyExclude` で対応を試みたが、`semver@6.3.1` → `chokidar@4.0.3` と次々に別パッケージで同エラーが発生。いずれも npm の provenance 普及前後の移行期（〜2024年）に公開された正規パッケージによる誤検知であるため、日付ベースで一括除外する方針に切り替える。

## Test plan

- [ ] このPRを `main` にマージ後、Renovate PR でリトライし `pnpm-lock.yaml` が正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)