### PR TITLE
fix: Renovate 実行時に trust-policy=none を注入して lockfile 更新失敗を解消

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -34,6 +34,9 @@
   // 最小リリース期間（新バージョンから一定期間待機）
   minimumReleaseAge: "5 days",
 
+  // pnpm の trustPolicy による誤検知を回避（Renovate 実行時のみ）
+  npmrc: "trust-policy=none",
+
   // eslint-plugin-react が ESLint v10 未対応のため v8 に固定
   packageRules: [
     {


### PR DESCRIPTION
## Summary

- `renovate.json5` に `npmrc: "trust-policy=none"` を追加
- Renovate が `pnpm-lock.yaml` を再生成する際の `ERR_PNPM_TRUST_DOWNGRADE` エラーを修正

## 背景

`pnpm-workspace.yaml` の `trustPolicy: no-downgrade` により、`semver@6.3.1`・`chokidar@4.0.3` 等の正規パッケージで誤検知が続き Renovate が `pnpm-lock.yaml` を再生成できない状態が続いていた。

`trustPolicyExclude` や `trustPolicyIgnoreAfter` での対処も Renovate 環境では効果がなかったため、`npmrc` オプションで Renovate 実行時のみ `.npmrc` に `trust-policy=none` を注入する方式を採用。ローカル開発環境の `pnpm-workspace.yaml` 設定はそのまま維持される。

## Test plan

- [ ] このPRを `main` にマージ後、Renovate PR（#327, #328, #329）でリトライし `pnpm-lock.yaml` が正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)