### PR TITLE
fix: trustPolicy を削除して Renovate の lockfile 更新失敗を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: "2025-01-01"
-
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` から `trustPolicy: no-downgrade` と `trustPolicyIgnoreAfter` を削除

## 背景

`trustPolicy: no-downgrade` により Renovate が `pnpm-lock.yaml` を再生成できない状態が長期化していた。以下の対処をすべて試みたが、いずれも `pnpm-workspace.yaml` の設定が優先されるため効果がなかった：

1. `trustPolicyExclude: [semver@6.3.1]` → 別パッケージ（chokidar@4.0.3）で再発
2. `trustPolicyIgnoreAfter: "2025-01-01"` → Renovate 環境では無効
3. `renovate.json5` の `npmrc: "trust-policy=none"` → `pnpm-workspace.yaml` に上書きされる

根本的に `pnpm-workspace.yaml` を変更しない限り解決しないため、設定を削除する。

## Test plan

- [ ] このPRを `main` にマージ後、Renovate PR（#327, #328, #329）でリトライし `pnpm-lock.yaml` が正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)