### PR TITLE
fix: lockFileMaintenance の minimumReleaseAge を 0 にして永久PENDINGを解消

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -46,8 +46,11 @@
   ],
 
   // ロックファイルメンテナンス
+  // minimumReleaseAge を 0 にして、毎週の force-push で待機日数が
+  // リセットされ続けマージ不能になるのを防ぐ
   lockFileMaintenance: {
     enabled: true,
     schedule: ["before 10am on monday"],
+    minimumReleaseAge: "0 days",
   },
 }


### PR DESCRIPTION
## Summary
- PR #365 (`chore(deps): lock file maintenance`) が長期間マージできない状態だった原因を調査
- `lockFileMaintenance` ブランチは毎週スケジュール (`before 10am on monday`) で force-push により作り直されるため、`minimumReleaseAge: "5 days"` の待機カウントがその都度リセットされ、`renovate/stability-days` ステータスチェックが永久に PENDING のままになっていた
- `lockFileMaintenance` ブロック内で `minimumReleaseAge: "0 days"` を上書きし、ロックファイルメンテナンスPRのみ待機期間チェックを免除するよう修正

## Test plan
- [ ] renovate.json5 の構文が正しいことを確認 (Renovateの設定検証が通ること)
- [ ] マージ後、次回の lockFileMaintenance PR で stability-days チェックが即座に解消されることを確認